### PR TITLE
Incorporate Kerry's fix for double escaped messages.

### DIFF
--- a/lib/LedSign/M500.pm
+++ b/lib/LedSign/M500.pm
@@ -682,6 +682,8 @@ sub processTags {
         }
         $msgdata =~ s/$pausetag/$substitute/;
     }
+
+    # time / date
     while ( $msgdata =~ /(<t:([^>]+)>)/gi ) {
         my $timetag = $1;
         my $time    = $2;
@@ -695,8 +697,6 @@ sub processTags {
         $msgdata =~ s/$timetag/$substitute/;
     }
 
-    # time / date
-    $this->{data} = $msgdata;
     return $msgdata;
 }
 


### PR DESCRIPTION
When sending a message to a second device, the control characters
were being displayed instead of acted on.
