### PR TITLE
Added the header to the beginning of the message

### DIFF
--- a/lib/LedSign/M500.pm
+++ b/lib/LedSign/M500.pm
@@ -599,7 +599,7 @@ sub encode {
         $msg .= $pause;
     }
     $msgdata .= "\r\r\r";
-    $msg .= $msgdata;
+    $msg = $header . $msg . $msgdata;
     # End of Text - ETX
     # Supposed to be a checksum - sign seems to ignore it though.
     # EOT - End of Transmission


### PR DESCRIPTION
The header wasn't being sent to the device which was causing effects and possibly other options to not function properly.